### PR TITLE
Portable wheels for Apple Silicon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ defaults:
 env:
   BUILD_TYPE: Release
   CMAKE_BUILD_PARALLEL_LEVEL: 2
-  Z3_GIT_TAG: z3-4.8.10
+  Z3_GIT_TAG: z3-4.8.14
 
 jobs:
   codestyle:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,9 @@ on:
   workflow_dispatch:
 
 env:
-  Z3_GIT_TAG: z3-4.8.13
+  Z3_GIT_TAG:   z3-4.8.14
+  Z3_HASH:      884f1128a33ea7dea3ad375e50ef5ea36b26623e2999119cf31252dd4650692f
+  CIBW_VERSION: v2.3.1
 
 jobs:
   build_manylinux_wheels:
@@ -26,7 +28,7 @@ jobs:
         with:
           python-version: '3.9'
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.3.0
+        uses: pypa/cibuildwheel@${{ env.CIBW_VERSION }}
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
@@ -46,13 +48,37 @@ jobs:
       - name: Install Z3
         run:  brew install z3
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.3.0
+        uses: pypa/cibuildwheel@{{ env.CIBW_VERSION }}
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_macos_m1_wheels:
+    name:    Build wheels on macOS for Apple Silicon
+    runs-on: macos-11
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.9'
+      - name: Install Z3
+        run:  |
+              curl -L -H "Authorization: Bearer QQ==" -o z3.tar.gz https://ghcr.io/v2/homebrew/core/z3/blobs/sha256:{{ env.Z3_HASH }}
+              brew install -f z3.tar.gz
+      - name: Build wheels
+        uses: pypa/cibuildwheel@{{ env.CIBW_VERSION }}
+        env:
+          CIBW_ARCHS_MACOS: arm64
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
 
   build_windows_wheels:
-    name: Build wheels on Windows
+    name:    Build wheels on Windows
     runs-on: windows-latest
 
     steps:
@@ -82,7 +108,7 @@ jobs:
         working-directory: ${{github.workspace}}/z3/build
         run: cmake --build . --config Release --target INSTALL;
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.3.0
+        uses: pypa/cibuildwheel@{{ env.CIBW_VERSION }}
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           python-version: '3.9'
       - name: Build wheels
-        uses: pypa/cibuildwheel@$v2.3.1
+        uses: pypa/cibuildwheel@v2.3.1
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
@@ -65,8 +65,8 @@ jobs:
         with:
           python-version: '3.9'
       - name: Install Z3
-        run:  |
-              curl -L -H "Authorization: Bearer QQ==" -o z3.tar.gz https://ghcr.io/v2/homebrew/core/z3/blobs/sha256:{{ env.Z3_HASH }}
+        run: |
+             curl -L -H "Authorization: Bearer QQ==" -o z3.tar.gz https://ghcr.io/v2/homebrew/core/z3/blobs/sha256:${{ env.Z3_HASH }}
               brew install -f z3.tar.gz
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.3.1
@@ -136,7 +136,7 @@ jobs:
           path: dist/*.tar.gz
 
   upload_pypi:
-    needs: [build_manylinux_wheels, build_macos_wheels, build_windows_wheels, build_sdist]
+    needs: [ build_manylinux_wheels, build_macos_wheels, build_macos_m1_wheels, build_windows_wheels, build_sdist ]
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,6 @@ on:
 env:
   Z3_GIT_TAG:   z3-4.8.14
   Z3_HASH:      884f1128a33ea7dea3ad375e50ef5ea36b26623e2999119cf31252dd4650692f
-  CIBW_VERSION: v2.3.1
 
 jobs:
   build_manylinux_wheels:
@@ -28,7 +27,7 @@ jobs:
         with:
           python-version: '3.9'
       - name: Build wheels
-        uses: pypa/cibuildwheel@${{ env.CIBW_VERSION }}
+        uses: pypa/cibuildwheel@$v2.3.1
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
@@ -48,7 +47,7 @@ jobs:
       - name: Install Z3
         run:  brew install z3
       - name: Build wheels
-        uses: pypa/cibuildwheel@{{ env.CIBW_VERSION }}
+        uses: pypa/cibuildwheel@v2.3.1
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
@@ -70,7 +69,7 @@ jobs:
               curl -L -H "Authorization: Bearer QQ==" -o z3.tar.gz https://ghcr.io/v2/homebrew/core/z3/blobs/sha256:{{ env.Z3_HASH }}
               brew install -f z3.tar.gz
       - name: Build wheels
-        uses: pypa/cibuildwheel@{{ env.CIBW_VERSION }}
+        uses: pypa/cibuildwheel@v2.3.1
         env:
           CIBW_ARCHS_MACOS: arm64
       - uses: actions/upload-artifact@v2
@@ -108,7 +107,7 @@ jobs:
         working-directory: ${{github.workspace}}/z3/build
         run: cmake --build . --config Release --target INSTALL;
       - name: Build wheels
-        uses: pypa/cibuildwheel@{{ env.CIBW_VERSION }}
+        uses: pypa/cibuildwheel@v2.3.1
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,8 +66,8 @@ jobs:
           python-version: '3.9'
       - name: Install Z3
         run: |
-             curl -L -H "Authorization: Bearer QQ==" -o z3.tar.gz https://ghcr.io/v2/homebrew/core/z3/blobs/sha256:${{ env.Z3_HASH }}
-              brew install -f z3.tar.gz
+             curl -L -H "Authorization: Bearer QQ==" -o z3-4.8.14.big_sur.bottle.tar.gz https://ghcr.io/v2/homebrew/core/z3/blobs/sha256:${{ env.Z3_HASH }}
+             brew install -f z3-4.8.14.big_sur.bottle.tar.gz
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.3.1
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,8 +66,8 @@ jobs:
           python-version: '3.9'
       - name: Install Z3
         run: |
-             curl -L -H "Authorization: Bearer QQ==" -o z3-4.8.14.big_sur.bottle.tar.gz https://ghcr.io/v2/homebrew/core/z3/blobs/sha256:${{ env.Z3_HASH }}
-             brew install -f z3-4.8.14.big_sur.bottle.tar.gz
+             curl -L -H "Authorization: Bearer QQ==" -o ${{ env.Z3_GIT_TAG }}.big_sur.bottle.tar.gz https://ghcr.io/v2/homebrew/core/z3/blobs/sha256:${{ env.Z3_HASH }}
+             brew install -f ${{ env.Z3_GIT_TAG }}.big_sur.bottle.tar.gz
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.3.1
         env:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "extern/qfr"]
 	path = extern/qfr
 	url = https://github.com/iic-jku/qfr.git
-	branch = revert-universal-binary
+	branch = master
     shallow = true

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "extern/qfr"]
 	path = extern/qfr
 	url = https://github.com/iic-jku/qfr.git
-	branch = master
+	branch = revert-universal-binary
     shallow = true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14...3.22)
 
 project(qmap
         LANGUAGES CXX
-        VERSION 1.5.0
+        VERSION 1.5.1
         DESCRIPTION "QMAP  - A JKQ library for mapping of quantum circuits to quantum architectures"
         )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,6 @@ endif ()
 
 # set deployment specific options
 if (DEPLOY)
-	# build a universal macOS binary in case this is a deployment build
-	set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "" FORCE)
 	# set the macOS deployment target appropriately
 	set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "" FORCE)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14...3.21)
+cmake_minimum_required(VERSION 3.14...3.22)
 
 project(qmap
         LANGUAGES CXX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,14 @@ if (DEFINED ENV{DEPLOY})
 	message(STATUS "Setting deployment configuration to '${DEPLOY}' from environment")
 endif ()
 
+# set deployment specific options
+if (DEPLOY)
+	# build a universal macOS binary in case this is a deployment build
+	set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "" FORCE)
+	# set the macOS deployment target appropriately
+	set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15" CACHE STRING "" FORCE)
+endif ()
+
 # build type settings
 set(default_build_type "Release")
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ build-backend = "setuptools.build_meta"
 build = "cp3*"
 skip = "*-win32 *-musllinux* *-manylinux_i686"
 test-skip = "*_arm64"
-manylinux-x86_64-image = "manylinux2014"
 test-command = "python -c \"from jkq import qmap\""
 environment = { DEPLOY = "ON" }
 build-verbosity = 3
@@ -16,7 +15,6 @@ before-all = "/opt/python/cp39-cp39/bin/python -m pip install z3-solver"
 environment = { LD_LIBRARY_PATH = "$LD_LIBRARY_PATH:/opt/python/cp39-cp39/lib/python3.9/site-packages/z3/lib", Z3_ROOT = "/opt/python/cp39-cp39/lib/python3.9/site-packages/z3", Z3_DIR = "/opt/python/cp39-cp39/lib/python3.9/site-packages/z3", DEPLOY = "ON" }
 
 [tool.cibuildwheel.macos]
-archs = "x86_64"
-environment = { MACOSX_DEPLOYMENT_TARGET = "10.15", DEPLOY = "ON" }
+archs = "x86_64 arm64"
 
 [tool.cibuildwheel.windows]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,5 +16,6 @@ environment = { LD_LIBRARY_PATH = "$LD_LIBRARY_PATH:/opt/python/cp39-cp39/lib/py
 
 [tool.cibuildwheel.macos]
 archs = "x86_64"
+environment = { MACOSX_DEPLOYMENT_TARGET = "10.15", DEPLOY = "ON" }
 
 [tool.cibuildwheel.windows]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,6 @@ before-all = "/opt/python/cp39-cp39/bin/python -m pip install z3-solver"
 environment = { LD_LIBRARY_PATH = "$LD_LIBRARY_PATH:/opt/python/cp39-cp39/lib/python3.9/site-packages/z3/lib", Z3_ROOT = "/opt/python/cp39-cp39/lib/python3.9/site-packages/z3", Z3_DIR = "/opt/python/cp39-cp39/lib/python3.9/site-packages/z3", DEPLOY = "ON" }
 
 [tool.cibuildwheel.macos]
-archs = "x86_64 arm64"
+archs = "x86_64"
 
 [tool.cibuildwheel.windows]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import platform
+import re
 import subprocess
 
 from setuptools import setup, Extension, find_namespace_packages
@@ -41,7 +42,7 @@ class CMakeBuild(build_ext):
         if platform.system() == "Windows":
             cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), extdir)]
             cmake_args += ['-T', 'ClangCl']
-            if sys.maxsize > 2**32:
+            if sys.maxsize > 2 ** 32:
                 cmake_args += ['-A', 'x64']
             build_args += ['--', '/m']
         else:
@@ -50,6 +51,14 @@ class CMakeBuild(build_ext):
             if cpus is None:
                 cpus = 2
             build_args += ['--', '-j{}'.format(cpus)]
+
+        # cross-compile support for macOS - respect ARCHFLAGS if set
+        if sys.platform.startswith("darwin"):
+            archs = re.findall(r"-arch (\S+)", os.environ.get("ARCHFLAGS", ""))
+            if archs:
+                arch_argument = "-DCMAKE_OSX_ARCHITECTURES={}".format(";".join(archs))
+                print('macOS building with: ', arch_argument, flush=True)
+                cmake_args += [arch_argument]
 
         env = os.environ.copy()
         env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get('CXXFLAGS', ''),

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ with open(README_PATH) as readme_file:
 
 setup(
     name='jkq.qmap',
-    version='1.5.0',
+    version='1.5.1',
     author='Lukas Burgholzer',
     author_email='lukas.burgholzer@jku.at',
     description='QMAP - A JKQ tool for Quantum Circuit Mapping',

--- a/src/Architecture.cpp
+++ b/src/Architecture.cpp
@@ -40,7 +40,7 @@ void Architecture::loadCouplingMap(std::istream&& is) {
         if (std::regex_match(line, m, r_nqubits)) {
             nqubits = static_cast<unsigned short>(std::stoul(m.str(1)));
         } else {
-            throw QMAPException("No qubit count found in coupling map file.");
+            throw QMAPException("No qubit count found in coupling map file: " + line);
         }
     } else {
         throw QMAPException("Error reading coupling map file.");
@@ -52,7 +52,7 @@ void Architecture::loadCouplingMap(std::istream&& is) {
             auto v2 = static_cast<unsigned short>(std::stoul(m.str(2)));
             couplingMap.emplace(v1, v2);
         } else {
-            throw QMAPException("No qubit count found in coupling map file.");
+            throw QMAPException("Could not identify edge in coupling map file: " + line);
         }
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,7 +38,8 @@ macro(package_add_test TESTNAME LIBRARY)
 endmacro()
 
 package_add_test(${PROJECT_NAME}_heuristic_test heuristic
-                 ${CMAKE_CURRENT_SOURCE_DIR}/test_heuristic.cpp)
+                 ${CMAKE_CURRENT_SOURCE_DIR}/test_heuristic.cpp
+				 ${CMAKE_CURRENT_SOURCE_DIR}/test_general.cpp)
 
 if (TARGET ${PROJECT_NAME}_exact_lib)
 	package_add_test(${PROJECT_NAME}_exact_test exact

--- a/test/test_general.cpp
+++ b/test/test_general.cpp
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the JKQ QMAP library which is released under the MIT license.
+ * See file README.md or go to https://iic.jku.at/eda/research/ibm_qx_mapping/ for more information.
+ */
+
+#include "Architecture.hpp"
+
+#include "gtest/gtest.h"
+#include <iostream>
+
+TEST(General, LoadCouplingMapNonexistentFile) {
+    EXPECT_THROW(Architecture("path/that/does/not/exist"), QMAPException);
+}
+
+TEST(General, LoadCouplingMapEmptyFile) {
+    std::ofstream ofs("test.arch");
+    EXPECT_THROW(Architecture("test.arch"), QMAPException);
+}
+
+TEST(General, LoadCouplingMapNoQubitCount) {
+    std::ofstream ofs("test.arch");
+    ofs << "noqubits\n";
+    EXPECT_THROW(Architecture("test.arch"), QMAPException);
+}
+
+TEST(General, LoadCouplingMapNoEdge) {
+    std::ofstream ofs("test.arch");
+    ofs << "1\n"
+        << "noedge\n";
+    EXPECT_THROW(Architecture("test.arch"), QMAPException);
+}
+
+TEST(General, LoadCalibrationDataNonexistentFile) {
+    std::ofstream ofs("test.arch");
+    ofs << "2\n"
+        << "0 1\n";
+    EXPECT_THROW(Architecture("test.arch", "path/that/does/not/exist"), QMAPException);
+}

--- a/test/test_general.cpp
+++ b/test/test_general.cpp
@@ -14,12 +14,14 @@ TEST(General, LoadCouplingMapNonexistentFile) {
 
 TEST(General, LoadCouplingMapEmptyFile) {
     std::ofstream ofs("test.arch");
+    ofs.close();
     EXPECT_THROW(Architecture("test.arch"), QMAPException);
 }
 
 TEST(General, LoadCouplingMapNoQubitCount) {
     std::ofstream ofs("test.arch");
     ofs << "noqubits\n";
+    ofs.close();
     EXPECT_THROW(Architecture("test.arch"), QMAPException);
 }
 
@@ -27,6 +29,7 @@ TEST(General, LoadCouplingMapNoEdge) {
     std::ofstream ofs("test.arch");
     ofs << "1\n"
         << "noedge\n";
+    ofs.close();
     EXPECT_THROW(Architecture("test.arch"), QMAPException);
 }
 
@@ -34,5 +37,6 @@ TEST(General, LoadCalibrationDataNonexistentFile) {
     std::ofstream ofs("test.arch");
     ofs << "2\n"
         << "0 1\n";
+    ofs.close();
     EXPECT_THROW(Architecture("test.arch", "path/that/does/not/exist"), QMAPException);
 }


### PR DESCRIPTION
Up until now, building portable wheels for Apple Silicon did not work properly. This is due to our setup not producing binaries for `arm64`. This PR changes that by allowing to infer the architecture from the environment in `setup.py`.
The external z3 dependency is resolved by downloading the corresponding Apple Silicon bottle from `brew` and installing it manually.